### PR TITLE
Base image bump

### DIFF
--- a/xboxone/build.json
+++ b/xboxone/build.json
@@ -1,11 +1,11 @@
 {
     "squash": false,
     "build_from": {
-        "aarch64": "hassioaddons/base-aarch64:3.0.1",
-        "amd64": "hassioaddons/base-amd64:3.0.1",
-        "armhf": "hassioaddons/base-armhf:3.0.1",
-        "armv7": "hassioaddons/base-armv7:3.0.1",
-        "i386": "hassioaddons/base-i386:3.0.1"
+        "aarch64": "hassioaddons/base-aarch64:4.0.3",
+        "amd64": "hassioaddons/base-amd64:4.0.3",
+        "armhf": "hassioaddons/base-armhf:4.0.3",
+        "armv7": "hassioaddons/base-armv7:4.0.3",
+        "i386": "hassioaddons/base-i386:4.0.3"
     },
     "args": {}
 }


### PR DESCRIPTION
Seems to fix an issue seen on ARM builds, but it looks like this should be done either way. Tested only on RPi 3.